### PR TITLE
fix(firestore-send-twilio-message): added secret type for twilio auth token

### DIFF
--- a/firestore-send-twilio-message/extension.yaml
+++ b/firestore-send-twilio-message/extension.yaml
@@ -118,7 +118,6 @@ params:
     type: secret
     description: >-
       Your Twilio Auth Token, which you can find in your Twilio console.
-    type: string
     example: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     validationRegex: ^[a-f0-9]{32}$
     validationErrorMessage: Invalid Auth Token. Must be 32 characters long and made of letters and digits.


### PR DESCRIPTION
A new type for secrets/passwords is due to be released, this ensures that the Twilio auth token will have this type when it becomes available.