### PR TITLE
fix(firestore-send-twilio-message) rename message collection in post install documentation

### DIFF
--- a/firestore-send-twilio-message/POSTINSTALL.md
+++ b/firestore-send-twilio-message/POSTINSTALL.md
@@ -4,7 +4,7 @@ You can test out this extension right away!
 
 1.  Go to your [Cloud Firestore dashboard](https://console.firebase.google.com/project/${param:PROJECT_ID}/firestore/data) in the Firebase console.
 
-1.  If it doesn't already exist, create the collection you specified during installation: `${param:MESSAGES_COLLECTION}`.
+1.  If it doesn't already exist, create the collection you specified during installation: `${param:MESSAGE_COLLECTION}`.
 
 1.  Add a document with a `to` field and a `body` field with the following content:
 
@@ -13,7 +13,7 @@ You can test out this extension right away!
     body: "Hello from Firebase!"
     ```
 
-2.  In a few seconds, you'll see a `delivery` field appear in the document. The field will update as the extension processes the message.
+1.  In a few seconds, you'll see a `delivery` field appear in the document. The field will update as the extension processes the message.
 
 **Note:** You can also use the [Firebase Admin SDK](https://firebase.google.com/docs/admin/setup) to add a document:
 


### PR DESCRIPTION
Postinstall documentation does not autofill the message collection configuration. 

Eg.

![image](https://user-images.githubusercontent.com/2060661/135466314-452a7682-70bd-4378-b83d-9c75353aafbf.png)

This PR updates the postinstall to correctly show the value.

- [x] I acknowledge that all my contributions will be made under the project's license.
