### PR TITLE
fix(firestore-send-twilio-message): added any type for error message

### DIFF
--- a/firestore-send-twilio-message/functions/src/processQueue.ts
+++ b/firestore-send-twilio-message/functions/src/processQueue.ts
@@ -51,7 +51,7 @@ async function deliverMessage(
     functions.logger.log(
       `Delivered message: ${ref.path} successfully. MessageSid: ${info.messageSid}`
     );
-  } catch (error) {
+  } catch (error: any) {
     update["delivery.state"] = "ERROR";
     update["delivery.errorCode"] = error.code;
     update["delivery.errorMessage"] = `${error.message} ${error.moreInfo}`;


### PR DESCRIPTION
Building the projects with `typescript` will throw the following error...

```js
  src/processQueue.ts(56,36): error TS2571: Object is of type 'unknown'.
  src/processQueue.ts(57,42): error TS2571: Object is of type 'unknown'.
  src/processQueue.ts(57,59): error TS2571: Object is of type 'unknown'.
  src/processQueue.ts(59,54): error TS2571: Object is of type 'unknown'.
```

Added `any` type on error to suppress this error.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
