### PR TITLE
fix(abandoned-cart-emails): added auth iam permissions

### DIFF
--- a/abandoned-cart-emails/extension.yaml
+++ b/abandoned-cart-emails/extension.yaml
@@ -25,6 +25,9 @@ roles:
   - role: datastore.user
     reason: Allows this extension to access Cloud Firestore to read and process added message documents.
 
+  - role: firebaseauth.viewer
+    reason: Allows this extension to access Firebase Auth to read user information.
+
 resources:
   - name: processEmailQueue
     type: firebaseextensions.v1beta.function


### PR DESCRIPTION
<!-- Describe your Pull Request -->

In production, the extension required the role `firebaseauth.viewer` to access user information.

Without this permission the logs will show an error

```
FirebaseAuthError: Credential implementation provided to initializeApp() via the "credential" property has insufficient permission to access the requested resource.
```

When accessing the cart collection for a specific user.

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
