### PR TITLE
Fix for mediaUrl

### DIFF
--- a/send-message/functions/src/processQueue.ts
+++ b/send-message/functions/src/processQueue.ts
@@ -28,12 +28,12 @@ async function deliverMessage(
       payload.from ||
       config.twilio.messagingServiceSid ||
       config.twilio.phoneNumber;
-    const { to, body, mediaUrls } = payload;
+    const { to, body, mediaUrl } = payload;
     const message = await twilioClient.messages.create({
       from,
       to,
       body,
-      mediaUrl: mediaUrls,
+      MediaUrl: mediaUrl,
       statusCallback: getFunctionsUrl("statusCallback"),
     });
     const info = {

--- a/send-message/functions/src/processQueue.ts
+++ b/send-message/functions/src/processQueue.ts
@@ -33,7 +33,7 @@ async function deliverMessage(
       from,
       to,
       body,
-      MediaUrl: mediaUrl,
+      mediaUrl,
       statusCallback: getFunctionsUrl("statusCallback"),
     });
     const info = {

--- a/send-message/functions/src/types.ts
+++ b/send-message/functions/src/types.ts
@@ -32,5 +32,5 @@ export type QueuePayload = {
   to: string;
   from: string;
   body: string;
-  mediaUrls?: string[];
+  MediaUrl?: string;
 };

--- a/send-message/functions/src/types.ts
+++ b/send-message/functions/src/types.ts
@@ -32,5 +32,5 @@ export type QueuePayload = {
   to: string;
   from: string;
   body: string;
-  mediaUrl?: string;
+  mediaUrl?: string[];
 };

--- a/send-message/functions/src/types.ts
+++ b/send-message/functions/src/types.ts
@@ -32,5 +32,5 @@ export type QueuePayload = {
   to: string;
   from: string;
   body: string;
-  MediaUrl?: string;
+  mediaUrl?: string;
 };


### PR DESCRIPTION
Fix to include an image when sending an SMS. Spoke with Twilio support and they confirmed that key (MediaUrl) is case sensitive and supports only one message at a time.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
