### PR TITLE
Corrected field name for optional mediaUrl

### DIFF
--- a/send-message/POSTINSTALL.md
+++ b/send-message/POSTINSTALL.md
@@ -44,7 +44,7 @@ After its installation, this extension monitors all document writes to the `${pa
 | Field       | Description                                                                                                                                                                                                         |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `from`      | A Twilio phone number or [Messaging Service](https://www.twilio.com/docs/messaging/services) you want to use to send the message. Overrides the from number or Messaging Service set in the extension settings      |
-| `mediaUrls` | An array of URLs of media to send with the message. Only supported in US and Canada. See the [Create a Message docs](https://www.twilio.com/docs/sms/api/message-resource#create-a-message-resource) for more info. |
+| `mediaUrl` | An array of URLs of media to send with the message. Only supported in US and Canada. See the [Create a Message docs](https://www.twilio.com/docs/sms/api/message-resource#create-a-message-resource) for more info. |
 
 #### Security rules and sending messages
 


### PR DESCRIPTION
The field name 'mediaUrls' does not work

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
