### PR TITLE
Added EventArc handler to send messages

### DIFF
--- a/send-message/PREINSTALL.md
+++ b/send-message/PREINSTALL.md
@@ -1,4 +1,4 @@
-Use this extension to send messages (SMS or WhatsApp) using the [Twilio Programmable Messaging API](https://www.twilio.com/docs/messaging) based on information from documents added to a specified Cloud Firestore collection. The extension will also record the delivery status of each message.
+Use this extension to send messages (SMS or WhatsApp) using the [Twilio Programmable Messaging API](https://www.twilio.com/docs/messaging) through custom events or based on information from documents added to a specified Cloud Firestore collection. The extension will also record the delivery status of each message.
 
 Adding a document triggers this extension to send a message built from the document's fields. The document's fields specify who to send the message to and the body of the message and can optionally define the number to send the message from.
 

--- a/send-message/README.md
+++ b/send-message/README.md
@@ -2,12 +2,12 @@
 
 **Author**: Twilio (**[https://www.twilio.com](https://www.twilio.com)**)
 
-**Description**: Sends a message using the Twilio API based on Custom Events or the contents of a document written to a specified Cloud Firestore collection.
+**Description**: Sends a message using the Twilio API using Eventarc custom events or based on the contents of a document written to a specified Cloud Firestore collection.
 
 
 
-**Details**: Use this extension to send messages (SMS or WhatsApp) using the [Twilio Programmable Messaging API](https://www.twilio.com/docs/messaging) based on Custom Events or information from documents added to a specified Cloud Firestore collection. The extension will also record the delivery status of each message.
-
+**Details**: Use this extension to send messages (SMS or WhatsApp) using the [Twilio Programmable Messaging API](https://www.twilio.com/docs/messaging) using custom events or based on information from documents added to a specified Cloud Firestore collection. The extension will also record the delivery status of each message.
+#### Method 1: Add a document to a Cloud Firestore Collection
 Adding a document triggers this extension to send a message built from the document's fields. The document's fields specify who to send the message to and the body of the message and can optionally define the number to send the message from.
 
 Here's an example document that would trigger this extension:
@@ -17,6 +17,20 @@ admin.firestore().collection('messages').add({
   to: '+15551234567',
   body: 'Hello from Firebase!'
 });
+```
+#### Method 2: Publishing an Eventarc custom event
+
+Publishing an event to a channel using `"firebase.extensions.twilio.send.sms"` as the `type` triggers this extension to send a message built with the given data.
+
+Here's an example of how to publish this custom event:
+```js
+  getEventarc().channel().publish({
+    type: "firebase.extensions.twilio.send.sms",
+    data: {
+      to: '+15551234567',
+      body: 'Hello from Firebase!'
+    },
+  });
 ```
 
 #### Required fields

--- a/send-message/README.md
+++ b/send-message/README.md
@@ -2,11 +2,11 @@
 
 **Author**: Twilio (**[https://www.twilio.com](https://www.twilio.com)**)
 
-**Description**: Sends a message using the Twilio API based on the contents of a document written to a specified Cloud Firestore collection.
+**Description**: Sends a message using the Twilio API based on Custom Events or the contents of a document written to a specified Cloud Firestore collection.
 
 
 
-**Details**: Use this extension to send messages (SMS or WhatsApp) using the [Twilio Programmable Messaging API](https://www.twilio.com/docs/messaging) based on information from documents added to a specified Cloud Firestore collection. The extension will also record the delivery status of each message.
+**Details**: Use this extension to send messages (SMS or WhatsApp) using the [Twilio Programmable Messaging API](https://www.twilio.com/docs/messaging) based on Custom Events or information from documents added to a specified Cloud Firestore collection. The extension will also record the delivery status of each message.
 
 Adding a document triggers this extension to send a message built from the document's fields. The document's fields specify who to send the message to and the body of the message and can optionally define the number to send the message from.
 

--- a/send-message/extension.yaml
+++ b/send-message/extension.yaml
@@ -41,6 +41,20 @@ resources:
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${param:PROJECT_ID}/databases/(default)/documents/${param:MESSAGE_COLLECTION}/{id}
+  - name: onsend
+    type: firebaseextensions.v1beta.v2function
+    description:
+      Listens for events emitted from your application or other extensions, you granted permission to emit this event, and sends the provided message.
+    properties:
+      location: ${param:LOCATION}
+      buildConfig:
+        runtime: nodejs14
+      serviceConfig:
+        availableMemory: 512M
+        timeoutSeconds: 60
+      eventTrigger:
+        eventType: firebase.extensions.twilio.send.sms
+        channel: projects/${param:PROJECT_ID}/locations/${param:LOCATION}/channels/firebase
   - name: statusCallback
     type: firebaseextensions.v1beta.function
     description: >-

--- a/send-message/extension.yaml
+++ b/send-message/extension.yaml
@@ -25,6 +25,12 @@ externalServices:
   - name: Twilio
     PricingUri: https://www.twilio.com/pricing
 
+apis:
+  - apiName: eventarc.googleapis.com
+    reason: Powers all events and triggers
+  - apiName: run.googleapis.com
+    reason: Powers v2 functions
+
 roles:
   - role: datastore.user
     reason: Allows this extension to access Cloud Firestore to read and process added message documents.

--- a/send-message/extension.yaml
+++ b/send-message/extension.yaml
@@ -3,7 +3,7 @@ version: 0.2.1
 specVersion: v1beta
 
 displayName: Send Messages with Twilio
-description: Sends a message using the Twilio API based on the contents of a document written to a specified Cloud Firestore collection.
+description: Sends a message using the Twilio API based on custom events or the contents of a document written to a specified Cloud Firestore collection.
 
 license: Apache-2.0
 

--- a/send-message/extension.yaml
+++ b/send-message/extension.yaml
@@ -3,7 +3,7 @@ version: 0.2.1
 specVersion: v1beta
 
 displayName: Send Messages with Twilio
-description: Sends a message using the Twilio API based on custom events or the contents of a document written to a specified Cloud Firestore collection.
+description: Sends a message using the Twilio API using custom events or based on the contents of a document written to a specified Cloud Firestore collection.
 
 license: Apache-2.0
 

--- a/send-message/functions/src/eventsHandler.ts
+++ b/send-message/functions/src/eventsHandler.ts
@@ -1,0 +1,27 @@
+import config from "./config";
+import { initialize, twilioClient, getFunctionsUrl } from "./utils";
+import { eventarc } from "firebase-functions/v2";
+
+export const onsend = eventarc.onCustomEventPublished(
+    "firebase.extensions.twilio.send.sms",
+    async (event) => {
+      try {
+        // Initialize Twilio client
+        initialize();
+        const from =
+            event.data.from ||
+            config.twilio.messagingServiceSid ||
+            config.twilio.phoneNumber;
+        const { to, body, mediaUrl } = event.data;
+        return await twilioClient.messages.create({
+            from,
+            to,
+            body,
+            mediaUrl,
+            statusCallback: getFunctionsUrl("statusCallback"),
+        });
+      } catch(err) {
+        return Promise.reject(err);
+      }
+    }
+  );

--- a/send-message/functions/src/index.ts
+++ b/send-message/functions/src/index.ts
@@ -2,3 +2,4 @@
 
 export { statusCallback } from "./statusCallback";
 export { processQueue } from "./processQueue";
+export { onsend } from "./eventsHandler";


### PR DESCRIPTION
1) Added an event handler for the new Custom Events feature of Firebase extensions to allow the user, or third-party Extensions authorized by the user, to send messages without writing to Firestore.

To Send and SMS:

  import {getEventarc} from "firebase-admin/eventarc";

  getEventarc().channel().publish({
    type: "firebase.extensions.twilio.send.sms",
    data: {
      to:"+13055671234",
      body: "Hello, World!",
    },
  }); 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ X] I acknowledge that all my contributions will be made under the project's license.
